### PR TITLE
updated stac-to-dc call in REAMDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All you need to know:
   * `docker-compose exec jupyter datacube -v system init`
   * `docker-compose exec jupyter datacube product add https://raw.githubusercontent.com/digitalearthafrica/config/master/products/esa_s2_l2a.odc-product.yaml`
 * Index a default region with either:
-  * `docker-compose exec jupyter bash -c "stac-to-dc --bbox='25,20,35,30' --collections='sentinel-s2-l2a-cogs' --datetime='2020-01-01/2020-03-31' s2_l2a"`
+  * `docker-compose exec jupyter bash -c "stac-to-dc --bbox='25,20,35,30' --collections='sentinel-s2-l2a-cogs' --datetime='2020-01-01/2020-03-31'"`
 * Shutdown your local environment:
 * `docker-compose down`
 


### PR DESCRIPTION
Updated `stac-to-dc` call in `README.md` to match recent changes to `odc-apps-dc-tools` (the name input is not accepted anymore and results in an error: `Error: Got unexpected extra argument (s2_l2a)`). Similar to the changes in the indexing notebook but for the command line call (https://github.com/opendatacube/cube-in-a-box/commit/423dd53c90bff46e3cc5cd94d0d82a6b0e5b87f8)