### PR TITLE
Use numpy >=1.18 and upgade other python packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,12 +16,13 @@ odc-index
 gdal
 scipy
 jupyter==1.0.0
-jupyterlab==2.2.6
-ipyleaflet==0.13.0
+jupyterlab==3.2.0
+ipyleaflet==0.14.0
 folium
-pandas==1.0.5
+pandas==1.3.4
+numpy==1.18
 xarray==0.16.0
-matplotlib==3.2.1
+matplotlib==3.4.3
 geopandas
 scikit-image
 tqdm


### PR DESCRIPTION
It seems that I get an error while I try to setup the original data sets:

```
$ docker exec d9eb5bd07f9f datacube product add https://raw.githubusercontent.com/digitalearthafrica/config/master/products/esa_s2_l2a.odc-product.yaml
2021-10-18 14:33:55,773 8 datacube.drivers.driver_cache WARNING Failed to resolve driver datacube.plugins.index::default
2021-10-18 14:33:55,773 8 datacube.drivers.driver_cache WARNING Error was: ContextualVersionConflict(numpy 1.17.4 (/usr/lib/python3/dist-packages), Requirement.parse('numpy>=1.18; extra == "array"'), {'dask'})
```

Pinning numpy to version 1.18 as the error message suggests, seems to avoid the error.

Also took the opportunity to upgrade some other packages. They seem to work fine!