### PR TITLE
Unpin numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ jupyterlab==3.2.0
 ipyleaflet==0.14.0
 folium
 pandas==1.3.4
-numpy==1.18.5
+numpy
 xarray==0.16.0
 matplotlib==3.4.3
 geopandas


### PR DESCRIPTION
The pinned version of numpy was causing issues at runtime. The lastest version works fine.