### PR TITLE
Fix numpy version to 1.26.4 to solve conflict with specific Pandas version which has been causing `make setup` to fail.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ jupyterlab==3.2.0
 ipyleaflet
 folium
 pandas==1.3.4
-numpy
+numpy==1.26.4
 xarray==0.16.0
 matplotlib
 geopandas


### PR DESCRIPTION
Latest numpy version has problem with specific pandas version in requirements.txt causing `make setup` to fail. Last compatible version of numpy is 1.26.4 and is limited to that version in requirements.txt.